### PR TITLE
Show github upload progress in the leetcode when submitted

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -552,7 +552,7 @@ const loader = setInterval(() => {
 }, 1000);
 
 /* Since we dont yet have callbacks/promises that helps to find out if things went bad */
-/* we will start 6 seconds counter and even after that upload is not complete, then we conclude its failed */
+/* we will start 10 seconds counter and even after that upload is not complete, then we conclude its failed */
 function startUploadCountDown() {
   uploadState.uploading = true;
   uploadState['countdown'] = setTimeout(() => {
@@ -561,7 +561,7 @@ function startUploadCountDown() {
       uploadState.uploading = false;
       markUploadFailed();
     }
-  }, 6000);
+  }, 10000);
 }
 /* start upload will inject a spinner on left side to the "Run Code" button */
 function startUpload() {

--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -28,6 +28,9 @@ const discussionMsg = 'Prepend discussion post - LeetHub';
 /* Difficulty of most recenty submitted question */
 let difficulty = '';
 
+/* state of upload for progress */
+let uploadState = { uploading: false }
+
 /* Get file extension for submission */
 function findLanguage() {
   const tag = [
@@ -49,8 +52,8 @@ function findLanguage() {
   return null;
 }
 
-/* Main function for uploading code to GitHub repo */
-const upload = (token, hook, code, directory, filename, sha, msg) => {
+/* Main function for uploading code to GitHub repo, and callback cb is called if success */
+const upload = (token, hook, code, directory, filename, sha, msg, cb=undefined) => {
   // To validate user, load user object from GitHub.
   const URL = `https://api.github.com/repos/${hook}/contents/${directory}/${filename}`;
 
@@ -94,6 +97,11 @@ const upload = (token, hook, code, directory, filename, sha, msg) => {
             console.log(
               `Successfully committed ${filename} to github`,
             );
+
+            // if callback is defined, call it
+            if(cb !== undefined) {
+              cb();
+            }
           });
         });
       }
@@ -107,7 +115,8 @@ const upload = (token, hook, code, directory, filename, sha, msg) => {
 
 /* Main function for updating code on GitHub Repo */
 /* Currently only used for prepending discussion posts to README */
-const update = (token, hook, addition, directory, msg, prepend) => {
+/* callback cb is called on success if it is defined */
+const update = (token, hook, addition, directory, msg, prepend, cb=undefined) => {
   const URL = `https://api.github.com/repos/${hook}/contents/${directory}/README.md`;
 
   /* Read from existing file on GitHub */
@@ -138,6 +147,7 @@ const update = (token, hook, addition, directory, msg, prepend) => {
           'README.md',
           response.sha,
           msg,
+          cb
         );
       }
     }
@@ -155,6 +165,7 @@ function uploadGit(
   msg,
   action,
   prepend = true,
+  cb = undefined
 ) {
   /* Get necessary payload data */
   chrome.storage.local.get('leethub_token', (t) => {
@@ -193,6 +204,7 @@ function uploadGit(
                     fileName,
                     sha,
                     msg,
+                    cb
                   );
                 } else if (action === 'update') {
                   /* Update on git */
@@ -203,6 +215,7 @@ function uploadGit(
                     problemName,
                     msg,
                     prepend,
+                    cb
                   );
                 }
               });
@@ -218,7 +231,8 @@ function uploadGit(
 /* - At first find the submission details url. */
 /* - Then send a request for the details page. */
 /* - Finally, parse the code from the html reponse. */
-function findCode(uploadGit, problemName, fileName, msg, action) {
+/* - Also call the callback if available when upload is success */
+function findCode(uploadGit, problemName, fileName, msg, action, cb=undefined) {
 
   /* Get the submission details url from the submission page. */
   var submissionURL;
@@ -293,6 +307,8 @@ function findCode(uploadGit, problemName, fileName, msg, action) {
                   fileName,
                   msg,
                   action,
+                  true,
+                  cb
                 );
               }, 2000);
             }
@@ -487,6 +503,8 @@ const loader = setInterval(() => {
     const problemName = getProblemNameSlug();
     const language = findLanguage();
     if (language !== null) {
+      // start upload indicator here
+      startUpload();
       chrome.storage.local.get('stats', (s) => {
         const { stats } = s;
         const filePath = problemName + problemName + language;
@@ -520,11 +538,64 @@ const loader = setInterval(() => {
           problemName + language,
           probStats,
           'upload',
+          // callback is called when the code upload to git is a success
+          () => { 
+            if(uploadState['countdown']) clearTimeout(uploadState['countdown']); 
+            delete uploadState['countdown']
+            uploadState.uploading = false; 
+            markUploaded(); 
+          }
         ); // Encode `code` to base64
       }, 1000);
     }
   }
 }, 1000);
+
+/* Since we dont yet have callbacks/promises that helps to find out if things went bad */
+/* we will start 6 seconds counter and even after that upload is not complete, then we conclude its failed */
+function startUploadCountDown() {
+  uploadState.uploading = true;
+  uploadState['countdown'] = setTimeout(() => {
+    if (uploadState.uploading = true) {
+      // still uploading, then it failed
+      uploadState.uploading = false;
+      markUploadFailed();
+    }
+  }, 6000);
+}
+/* start upload will inject a spinner on left side to the "Run Code" button */
+function startUpload() {
+  elem = document.getElementById('leethub_progress_anchor_element')
+  if (elem !== undefined) {
+    elem = document.createElement('span')
+    elem.id = "leethub_progress_anchor_element"
+    elem.className = "runcode-wrapper__8rXm"
+    elem.style = "margin-right: 20px;padding-top: 2px;"
+  }
+  elem.innerHTML = `<div id="leethub_progress_elem" class="leethub_progress"></div>`
+  target = document.getElementsByClassName('action__38Xc')[0]
+  if (target.childNodes.length > 0) {
+    target.childNodes[0].prepend(elem)
+  }
+  // start the countdown
+  startUploadCountDown();
+}
+
+/* This will create a tick mark before "Run Code" button signalling LeetHub has done its job */
+function markUploaded() {
+  elem = document.getElementById("leethub_progress_elem");
+  elem.className = "";
+  style = 'display: inline-block;transform: rotate(45deg);height:24px;width:12px;border-bottom:7px solid #78b13f;border-right:7px solid #78b13f;'
+  elem.style = style;
+}
+
+/* This will create a failed tick mark before "Run Code" button signalling that upload failed */
+function markUploadFailed() {
+  elem = document.getElementById("leethub_progress_elem");
+  elem.className = "";
+  style = 'display: inline-block;transform: rotate(45deg);height:24px;width:12px;border-bottom:7px solid red;border-right:7px solid red;'
+  elem.style = style;
+}
 
 /* Sync to local storage */
 chrome.storage.local.get('isSync', (data) => {
@@ -549,3 +620,13 @@ chrome.storage.local.get('isSync', (data) => {
     console.log('LeetHub Local storage already synced!');
   }
 });
+
+// inject the style
+injectStyle();
+
+/* inject css style required for the upload progress feature */
+function injectStyle() {
+  const style = document.createElement('style');
+  style.textContent = '.leethub_progress {pointer-events: none;width: 2.0em;height: 2.0em;border: 0.4em solid transparent;border-color: #eee;border-top-color: #3E67EC;border-radius: 50%;animation: loadingspin 1s linear infinite;} @keyframes loadingspin { 100% { transform: rotate(360deg) }}';
+  document.head.append(style);
+}


### PR DESCRIPTION
LeetHub currently doesn't report any kind of progress when submission is being uploaded to GitHub. The only way to check if LeetHub uploaded the submission is to check if the submission count in the extension popup has increased or by checking the GitHub repo itself. This PR adds the functionality of showing upload progress directly in the Leetcode. When the submission is successful and the LeetHub upload is triggered, a progress spinner on the left side of the "Run Code" button pops up. If the upload is successful, the spinner is replaced by a green check. Currently, the LeetHub codebase doesn't have a proper way to pass success/failure of the upload calls, I have added a callback for success just for this purpose. Adding one for failure seems like a bit of work right now. So, this feature starts a timeout of 10 seconds (should be sufficient) after the upload has started. If the upload is not completed by the end of 10 seconds, then the upload is concluded to have failed and a red check replaces the spinner. 

Addresses #112 

![progresspr](https://user-images.githubusercontent.com/4876164/128619128-4e34d7c8-d8c6-432c-b998-335d7d76dcdb.gif)
