### PR TITLE
Add Question Link in leetcode readme file

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -414,7 +414,7 @@ function parseQuestion() {
       difficulty = 'Hard';
     }
     // Final formatting of the contents of the README for each problem
-    const markdown = `<h2>${qtitle}</h2><h3>${difficulty}</h3><hr><a href="${questionUrl}">Question Link</a><hr>${qbody}`;
+    const markdown = `<h2><a href="${questionUrl}">${qtitle}</a></h2><h3>${difficulty}</h3><hr>${qbody}`;
     return markdown;
   } else if(checkElem(questionDescriptionElem)){
     

--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -382,6 +382,10 @@ function getProblemNameSlug(){
 
 /* Parser function for the question and tags */
 function parseQuestion() {
+  var questionUrl = window.location.href
+  if(questionUrl.endsWith('/submissions/')){
+    questionUrl = questionUrl.substring(0, questionUrl.lastIndexOf("/submissions/")+1)
+  }
   const questionElem = document.getElementsByClassName(
     'content__u3I1 question-content__JfgR',
   );
@@ -410,7 +414,7 @@ function parseQuestion() {
       difficulty = 'Hard';
     }
     // Final formatting of the contents of the README for each problem
-    const markdown = `<h2>${qtitle}</h2><h3>${difficulty}</h3><hr>${qbody}`;
+    const markdown = `<h2>${qtitle}</h2><h3>${difficulty}</h3><hr><a href="${questionUrl}">Question Link</a><hr>${qbody}`;
     return markdown;
   } else if(checkElem(questionDescriptionElem)){
     


### PR DESCRIPTION
**Problem**
I often revisit my repo to see my solutions. I look at the readme file; which is enough to get me started for the question, but often I want to revisit the question. 
I would manually copy the title of the question and search it on google or leetcode. 
Which in my opinion is a doable task. But wouldn't it be nice to have a tiny question link in the file itself.

**Idea/Proposal**
Make readme file independent and robust.
The readme of individual question should be enough. 

**Solution**
I capture the `question link` on the submission and add it to the readme file.

**Details**
Browser type/version: Google Chrome Version 96.0.4664.110 (Official Build) (64-bit)
Operating system? PopOs 20.04 LTS


> This has been tested with simple explore problems set.

let me know what you think about it.
Have a good day 😄 

> I have attached ss for your ref.

![image](https://user-images.githubusercontent.com/58180803/146263415-6bc3369a-2792-48d8-9d84-b0098a95977e.png)





