### PR TITLE
Adding 'Related Topics' to the Commit Message

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -506,7 +506,7 @@ function parseStats() {
   for (let i = 0; i < relatedTags.length; i++) {
     allTags.push(relatedTags.item(i).innerText);
   }
-  let relatedTopics = allTags.join('| ');
+  let relatedTopics = allTags.join(' | ');
 
   // Format commit message
   return `Related Topics: ${relatedTopics}, Time: ${time} (${timePercentile}), Space: ${space} (${spacePercentile}) - LeetHub`;

--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -498,8 +498,18 @@ function parseStats() {
   const space = probStats[2].textContent;
   const spacePercentile = probStats[3].textContent;
 
+  /* Adding Related Topics in Commit Message */
+  const relatedTags = document.getElementsByClassName(
+    'topic-tag__1jni',
+  );
+  let allTags = [];
+  for (let i = 0; i < relatedTags.length; i++) {
+    allTags.push(relatedTags.item(i).innerText);
+  }
+  let relatedTopics = allTags.join('| ');
+
   // Format commit message
-  return `Time: ${time} (${timePercentile}), Space: ${space} (${spacePercentile}) - LeetHub`;
+  return `Related Topics: ${relatedTopics}, Time: ${time} (${timePercentile}), Space: ${space} (${spacePercentile}) - LeetHub`;
 }
 
 document.addEventListener('click', (event) => {


### PR DESCRIPTION
Modified the parseStats function to add the Related Topics that are there on the Problems page. Fixing #295 

Testing Evidence:
<img width="909" alt="Screenshot 2022-07-22 at 09 31 42" src="https://user-images.githubusercontent.com/95332530/180450026-6858e339-c369-4895-96c2-2a16fe491cb0.png">

