### PR TITLE
Added leading zeros to titles

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -424,7 +424,15 @@ function getProblemNameSlug() {
       questionTitle = qtitle[0].innerText;
     }
   }
-  return convertToSlug(questionTitle);
+  return addLeadingZeros(convertToSlug(questionTitle));
+}
+
+function addLeadingZeros(title) {
+  var len = title.split('-')[0].length;
+  if (len < 4) {
+    return '0'.repeat(4 - len) + title;
+  }
+  return title;
 }
 
 /* Parser function for the question and tags */

--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -428,8 +428,9 @@ function getProblemNameSlug() {
 }
 
 function addLeadingZeros(title) {
+  const maxTitlePrefixLength = 4;
   var len = title.split('-')[0].length;
-  if (len < 4) {
+  if (len < maxTitlePrefixLength) {
     return '0'.repeat(4 - len) + title;
   }
   return title;


### PR DESCRIPTION
Fix for #249 , #229 , #304

Adds leading zeros to all LeetCode file and directory names. Makes every title include a 4-digit question number to make file order on github repos consistent with natural ordering.

![Untitled](https://user-images.githubusercontent.com/62390840/188983341-a665fbc2-9a03-4644-999b-8ba5505241bb.png)
