### PR TITLE
Categorized problems with language and difficulty level for leetcode

### DIFF
--- a/scripts/leetcode.js
+++ b/scripts/leetcode.js
@@ -66,6 +66,7 @@ const upload = (
   msg,
   cb = undefined,
 ) => {
+  const languageName =  findLanguage().charAt(1).toUpperCase() + findLanguage().slice(2);
   // To validate user, load user object from GitHub.
   const URL = `https://api.github.com/repos/${hook}/contents/${directory}/${filename}`;
 
@@ -95,7 +96,7 @@ const upload = (
             stats.hard = 0;
             stats.sha = {};
           }
-          const filePath = directory + filename;
+          const filePath = languageName + '/' + difficulty + '/' + directory + filename;
           // Only increment solved problems statistics once
           // New submission commits twice (README and problem)
           if (filename === 'README.md' && sha === null) {


### PR DESCRIPTION
Hi, currently all problem folders are being created in the same folder. Normally, we practice with different programming languages. So, wouldn't it be better if we categorize the problems by "Language" and "Difficulty" level? That way we can easily find our solutions from github repo.
Structure would be something like the below - 
>Language-Name
          &nbsp;&nbsp;&nbsp;&nbsp;Difficulty // for example: Easy, Medium etc
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Problem-Name-1
             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Problem-Name-1

This PR related to issue #105 #111  