### PR TITLE
problem-count-formatting

### DIFF
--- a/welcome.html
+++ b/welcome.html
@@ -102,14 +102,18 @@
             styl="font-size: 2.3em"
             class="ui inverted large header"
           >
-            <span style="color: #5cb85c">Easy:</span>
-            <span id="p_solved_easy" style="color: #5cb85c">0 </span>
-            <span style="color: #f0ad4e">&ensp; &ensp; Medium:</span>
-            <span id="p_solved_medium" style="color: #f0ad4e"
-              >0
+            <span style="color: #5cb85c; white-space: nowrap"
+              >Easy:
+              <span id="p_solved_easy">0 </span>
             </span>
-            <span style="color: #d9534f">&ensp; &ensp; Hard:</span>
-            <span id="p_solved_hard" style="color: #d9534f">0 </span>
+            <span style="color: #f0ad4e; white-space: nowrap"
+              >&ensp; &ensp;Medium:
+              <span id="p_solved_medium">0 &ensp; &ensp; </span>
+            </span>
+            <span style="color: #d9534f; white-space: nowrap"
+              >Hard:
+              <span id="p_solved_hard">0 </span>
+            </span>
           </div>
         </div>
         <div class="eight wide center aligned column">

--- a/welcome.html
+++ b/welcome.html
@@ -108,7 +108,8 @@
             </span>
             <span style="color: #f0ad4e; white-space: nowrap"
               >&ensp; &ensp;Medium:
-              <span id="p_solved_medium">0 &ensp; &ensp; </span>
+              <span id="p_solved_medium">0 </span>
+              <span>&ensp; &ensp;</span>
             </span>
             <span style="color: #d9534f; white-space: nowrap"
               >Hard:


### PR DESCRIPTION
Perhaps a little nitpicky, forgive me

I noticed that the problem count number wraps before the difficulty, like this:
![image](https://user-images.githubusercontent.com/95369494/227776857-806d2b3c-e1a8-4087-9ae9-0fe3f2c06da3.png)

I thought it might be nice to force them to move together always, like this:
![image](https://user-images.githubusercontent.com/95369494/227776922-93f59553-23ce-4824-b05e-79cc86df8835.png)
I did this by changing the two spans to be a span within a span that is styled with white-space: nowrap

I also noticed with the current &ensp's, wrapping is a little uneven:
![image](https://user-images.githubusercontent.com/95369494/227777139-3e776126-f47b-40db-bfb8-12981bf10a36.png)

So I attempted to resolve that too:
![image](https://user-images.githubusercontent.com/95369494/227776799-595b089f-3eb0-4534-bced-b1c41e747f4c.png)
I did this by moving the spaces from before Medium and before Hard to before Medium and after the Medium count (in it's own span because I think it needs to be there to not break when the quantity is updated(?)
When only hard wraps below, the centering isn't perfect (bc of the space following the medium count), but when all difficulties are forced to their own lines, all three difficulties are centered properly.

Wrapping the count span within the difficulty span allowed me to remove the color styling on the count span(s).